### PR TITLE
Add OnelineFormat

### DIFF
--- a/lib/table_beet/cli.rb
+++ b/lib/table_beet/cli.rb
@@ -25,6 +25,7 @@ module TableBeet
           on :path=,   'Directory that contains step file. (default: ./spec)'
           on :suffix=, 'Suffix of step file  (default: _steps.rb)'
           on :n, :textmode, 'Display steps in plain text (No generate HTML)'
+          on :s, :oneline, 'Display steps in plain text (short mode)'
           on :v, :version, 'Print this version' do
             puts TableBeet::VERSION
             exit
@@ -33,15 +34,13 @@ module TableBeet
 
         exit if opts.present?(:help)
 
-        h = opts.to_hash
-        h.delete(:help)
-        h.delete(:version)
+        opts.to_hash.tap do |h|
+          h.delete(:help)
+          h.delete(:version)
 
-        if opts.textmode?
-          h[:format] = :text
+          h[:format] = :text if opts.textmode?
+          h[:format] = :oneline if opts.oneline?
         end
-
-        h
       end
   end
 end

--- a/lib/table_beet/formatters/oneline_formatter.rb
+++ b/lib/table_beet/formatters/oneline_formatter.rb
@@ -1,0 +1,15 @@
+require 'table_beet/formatters/base_formatter.rb'
+
+module TableBeet
+  module Formatters
+    class OnelineFormatter < BaseFormatter
+      def flush
+        @scopes.each do |name, steps|
+          steps.each do |step|
+            puts "[@#{name}] #{step.name} at:#{step.file}:#{step.lineno}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/table_beet/reporter.rb
+++ b/lib/table_beet/reporter.rb
@@ -1,5 +1,6 @@
 require 'table_beet/world'
 require 'table_beet/formatters/text_formatter'
+require 'table_beet/formatters/oneline_formatter'
 require 'table_beet/formatters/html_formatter'
 
 module TableBeet
@@ -22,6 +23,8 @@ module TableBeet
       case type
       when :t, :text
         TableBeet::Formatters::TextFormatter
+      when :s, :oneline
+        TableBeet::Formatters::OnelineFormatter
       else
         TableBeet::Formatters::HTMLFormatter
       end


### PR DESCRIPTION
``` diff
 Usage: table_beet [options]
         --output        Directory to output (default: ./stepdoc)
         --path          Directory that contains step file. (default: ./spec)
         --suffix        Suffix of step file  (default: _steps.rb)
     -n, --textmode      Display steps in plain text (No generate HTML)
+    -s, --oneline       Display steps in plain text (short mode)
     -v, --version       Print this version
     -h, --help          Display this help message.
```
